### PR TITLE
feat: support apiUrl configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ The documentation below refers to the `OpenFgaClient`, to read the documentation
 const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';
 
 const fgaClient = new OpenFgaClient({
-  apiScheme: process.env.FGA_API_SCHEME, // optional, defaults to "https"
-  apiHost: process.env.FGA_API_HOST, // required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+  apiUrl: process.env.FGA_API_URL, // required
   storeId: process.env.FGA_STORE_ID, // not needed when calling `CreateStore` or `ListStores`
   authorizationModelId: process.env.FGA_AUTHORIZATION_MODEL_ID, // Optional, can be overridden per request
 });
@@ -107,8 +106,7 @@ const fgaClient = new OpenFgaClient({
 const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';
 
 const fgaClient = new OpenFgaClient({
-  apiScheme: process.env.FGA_API_SCHEME, // optional, defaults to "https"
-  apiHost: process.env.FGA_API_HOST, // required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+  apiUrl: process.env.FGA_API_URL, // required
   storeId: process.env.FGA_STORE_ID, // not needed when calling `CreateStore` or `ListStores`
   authorizationModelId: process.env.FGA_AUTHORIZATION_MODEL_ID, // Optional, can be overridden per request
   credentials: {
@@ -126,8 +124,7 @@ const fgaClient = new OpenFgaClient({
 const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';
 
 const fgaClient = new OpenFgaClient({
-  apiScheme: process.env.FGA_API_SCHEME, // optional, defaults to "https"
-  apiHost: process.env.FGA_API_HOST, // required, define without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+  apiUrl: process.env.FGA_API_URL, // required
   storeId: process.env.FGA_STORE_ID, // not needed when calling `CreateStore` or `ListStores`
   authorizationModelId: process.env.FGA_AUTHORIZATION_MODEL_ID, // Optional, can be overridden per request
   credentials: {

--- a/configuration.ts
+++ b/configuration.ts
@@ -77,7 +77,7 @@ export class Configuration {
   private static sdkVersion = "0.3.1";
 
   /**
-   * provide the full api URL
+   * provide the full api URL (e.g. `https://api.fga.example`)
    *
    * @type {string}
    * @memberof Configuration

--- a/tests/helpers/default-config.ts
+++ b/tests/helpers/default-config.ts
@@ -15,7 +15,7 @@ import { Configuration, UserConfigurationParams } from "../../configuration";
 import { CredentialsMethod } from "../../credentials";
 
 export const OPENFGA_STORE_ID = "01H0H015178Y2V4CX10C2KGHF4";
-export const OPENFGA_API_HOST = "api.fga.example";
+export const OPENFGA_API_URL = "http://api.fga.example";
 export const OPENFGA_API_TOKEN_ISSUER = "tokenissuer.fga.example";
 export const OPENFGA_API_AUDIENCE = "https://api.fga.example/";
 export const OPENFGA_CLIENT_ID = "01H0H3D8TD07EWAQHXY9BWJG3V";
@@ -24,7 +24,7 @@ export const OPENFGA_API_TOKEN = "fga_abcdef";
 
 export const baseConfig: UserConfigurationParams = {
   storeId: OPENFGA_STORE_ID,
-  apiHost: OPENFGA_API_HOST,
+  apiUrl: OPENFGA_API_URL,
   credentials: {
     method: CredentialsMethod.ClientCredentials,
     config: {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -32,7 +32,7 @@ import { AuthCredentialsConfig } from "../credentials";
 import {
   baseConfig,
   defaultConfiguration,
-  OPENFGA_API_HOST,
+  OPENFGA_API_URL,
   OPENFGA_API_TOKEN_ISSUER,
   OPENFGA_STORE_ID
 } from "./helpers/default-config";
@@ -64,14 +64,26 @@ describe("OpenFGA SDK", function () {
 
     it("should require host in configuration", () => {
       expect(
-        () => new OpenFgaApi({ ...baseConfig, apiHost: undefined! })
+        () => new OpenFgaApi({ ...baseConfig, apiUrl: undefined! })
       ).toThrowError();
     });
 
     it("should validate host in configuration (adding scheme as part of the host)", () => {
       expect(
-        () => new OpenFgaApi({ ...baseConfig, apiHost: "https://api.fga.example" })
+        () => new OpenFgaApi({ ...baseConfig, apiUrl: "//api.fga.example" })
       ).toThrowError();
+    });
+
+    it("should allow using apiHost if apiUrl is not provided", () => {
+      expect(
+        () => new OpenFgaApi({ ...baseConfig, apiHost: "api.fga.example" })
+      ).not.toThrowError();
+    });
+
+    it("should still validate apiHost", () => {
+      expect(
+        () => new OpenFgaApi({ ...baseConfig, apiHost: "//api.fga.example" })
+      ).not.toThrowError();
     });
 
     it("should validate apiTokenIssuer in configuration (should not allow scheme as part of the apiTokenIssuer)", () => {
@@ -94,7 +106,7 @@ describe("OpenFGA SDK", function () {
         () =>
           new OpenFgaApi({
             storeId: baseConfig.storeId!,
-            apiHost: baseConfig.apiHost,
+            apiUrl: baseConfig.apiUrl,
           })
       ).not.toThrowError();
     });
@@ -104,7 +116,7 @@ describe("OpenFGA SDK", function () {
         () =>
           new OpenFgaApi({
             storeId: baseConfig.storeId!,
-            apiHost: baseConfig.apiHost,
+            apiUrl: baseConfig.apiUrl,
             credentials: {
               method: CredentialsMethod.ApiToken as any
             }
@@ -240,7 +252,7 @@ describe("OpenFGA SDK", function () {
 
       const fgaApi = new OpenFgaApi({
         storeId: baseConfig.storeId!,
-        apiHost: baseConfig.apiHost,
+        apiUrl: baseConfig.apiUrl,
       });
       expect(scope.isDone()).toBe(false);
 
@@ -258,7 +270,7 @@ describe("OpenFGA SDK", function () {
 
     it("should allow updating the storeId after initialization", async () => {
       const fgaApi = new OpenFgaApi({
-        apiHost: OPENFGA_API_HOST
+        apiUrl: OPENFGA_API_URL
       });
       expect(fgaApi.storeId).toBe(undefined);
       fgaApi.storeId = OPENFGA_STORE_ID;


### PR DESCRIPTION
## Description

Adds support for an `apiUrl` configuration option and deprecated the existing `apiHost` and `apiScheme` options

## References

Part of openfga/sdk-generator/issues/298
Generated from:  https://github.com/openfga/sdk-generator/pull/302

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
