### PR TITLE
feat: add example project

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -26,6 +26,10 @@ credentials/credentials.ts
 credentials/index.ts
 credentials/types.ts
 errors.ts
+example/Makefile
+example/README.md
+example/example1/example1.mjs
+example/example1/package.json
 git_push.sh
 index.ts
 package-lock.json

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,0 +1,15 @@
+all: run
+
+project_name=example1
+openfga_version=latest
+
+setup:
+	cd "${project_name}/" && npm install && cd -
+
+run:
+	cd "${project_name}" && \
+		npm run run-example
+
+run-openfga:
+	docker pull docker.io/openfga/openfga:${openfga_version} && \
+		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version} run

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,42 @@
+## Examples of using the OpenFGA JS SDK
+
+A set of Examples on how to call the OpenFGA JS SDK
+
+### Examples
+Example 1:
+A bare-bones example. It creates a store, and runs a set of calls against it including creating a model, writing tuples and checking for access.
+
+### Running the Examples
+
+Prerequisites:
+- `docker`
+- `make`
+- `Node.js` 16.13.0+
+
+#### Run using a published SDK
+
+Steps
+1. Clone/Copy the example folder
+2. If you have an OpenFGA server running, you can use it, otherwise run `make run-openfga` to spin up an instance (you'll need to switch to a different terminal after - don't forget to close it when done)
+3. Run `make setup` to install dependencies
+4. Run `make run` to run the example
+
+#### Run using a local unpublished SDK build
+
+Steps
+1. Build the SDK
+2. In the Example `package.json` change the `@openfga/sdk` dependency from a semver range to `file:../../`
+```json
+"dependencies": {
+    "@openfga/sdk": "^0.3.1"
+  }
+```
+and replace it with one pointing to the local gradle project, e.g.
+```groovy
+"dependencies": {
+    "@openfga/sdk": "file:../../"
+  }
+```
+3. If you have an OpenFGA server running, you can use it, otherwise run `make run-openfga` to spin up an instance (you'll need to switch to a different terminal after - don't forget to close it when done)
+4. Run `make setup` to install dependencies
+5. Run `make run` to run the example

--- a/example/example1/example1.mjs
+++ b/example/example1/example1.mjs
@@ -1,0 +1,286 @@
+import { Credentials, CredentialsMethod, FgaApiValidationError, OpenFgaClient, TypeName } from "@openfga/sdk";
+
+let credentials;
+if (process.env.FGA_CLIENT_ID) {
+  credentials = new Credentials({
+    method: CredentialsMethod.ClientCredentials,
+    config: {
+      clientId: process.env.FGA_CLIENT_ID,
+      clientSecret: process.env.FGA_CLIENT_SECRET,
+      apiAudience: process.env.FGA_API_AUDIENCE,
+      apiTokenIssuer: process.env.FGA_API_TOKEN_ISSUER
+    }
+  });
+}
+
+const fgaClient = new OpenFgaClient({
+  apiUrl: process.env.FGA_API_URL || "http://localhost:8080",
+  storeId: process.env.FGA_STORE_ID, // not needed when calling `createStore` or `listStores`
+  authorizationModelId: process.env.FGA_AUTHORIZATION_MODEL_ID, // optional, recommended for production,
+  credentials
+});
+
+console.log("Listing stores");
+try {
+  const stores = await fgaClient.listStores();
+  console.log(`Stores count: ${stores.stores.length}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Creating Test Store");
+let store;
+try {
+  const createdStore = await fgaClient.createStore({name: "Test Store"});
+  store = createdStore;
+  console.log(`Test Store ID: ${store.id}`);
+  fgaClient.storeId = store.id;
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Listing Stores");
+try {
+  const stores = await fgaClient.listStores();
+  console.log(`Stores count: ${stores.stores.length}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Getting Current Store");
+try {
+  const currentStore = await fgaClient.getStore();
+  console.log(`Current Store Name ${currentStore.name}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Reading Authorization Models");
+try {
+  const models = await fgaClient.readAuthorizationModels();
+  console.log(`Models Count: ${models.authorization_models.length}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Reading Latest Authorization Model");
+try {
+  const latestModel = await fgaClient.readLatestAuthorizationModel();
+  if (latestModel.authorization_model) {
+    console.log(`Latest Authorization Model ID: ${latestModel.authorization_model.id}`);
+  } else {
+    console.log("Latest Authorization Model not found");
+  }
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+let authorizationModelId;
+console.log("Writing an Authorization Model");
+try {
+  const model = await fgaClient.writeAuthorizationModel({
+    schema_version: "1.1",
+    type_definitions: [
+      {
+        type: "user"
+      },
+      {
+        type: "document",
+        relations: {
+          writer: { this: {} },
+          viewer: {
+            union: {
+              child: [
+                { this: {} },
+                {
+                  computedUserset: {
+                    relation: "writer"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        metadata: {
+          relations: {
+            writer: {
+              directly_related_user_types: [
+                { type: "user" },
+                { type: "user", condition: "ViewCountLessThan200" }
+              ]
+            },
+            viewer: {
+              directly_related_user_types: [
+                { type: "user" }
+              ]
+            }
+          }
+        }
+      },
+    ],
+    conditions: {
+      "ViewCountLessThan200": {
+        name: "ViewCountLessThan200",
+        expression: "ViewCount < 200",
+        parameters: {
+          ViewCount: {
+            type_name: TypeName.Int
+          },
+          Type: {
+            type_name: TypeName.String
+          },
+          Name: {
+            type_name: TypeName.String
+          }
+        }
+      }
+    }
+  });
+  authorizationModelId = model.authorization_model_id;
+  console.log(`Authorization Model ID: ${authorizationModelId}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Reading Authorization Models");
+try {
+  const models = await fgaClient.readAuthorizationModels();
+  console.log(`Models Count: ${models.authorization_models.length}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Reading Latest Authorization Model");
+try {
+  const latestModel = await fgaClient.readLatestAuthorizationModel();
+  console.log(`Latest Authorization Model ID: ${latestModel.authorization_model.id}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Writing Tuples");
+try {
+  await fgaClient.write({
+    writes: [
+      {
+        user: "user:anne",
+        relation: "writer",
+        object: "document:roadmap",
+        condition: {
+          name: "ViewCountLessThan200",
+          context: {
+            Name: "Roadmap",
+            Type: "document"
+          }
+        }
+      }
+    ]
+  }, { authorizationModelId });
+  console.log("Done Writing Tuples");
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+// Set the model ID
+fgaClient.authorizationModelId = authorizationModelId;
+
+console.log("Reading Tuples");
+try {
+  const { tuples } = await fgaClient.read();
+  console.log(`Read Tuples: ${JSON.stringify(tuples)}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Reading Tuple Changes");
+try {
+  const { changes } = await fgaClient.readChanges();
+  console.log(`Tuple Changes: ${JSON.stringify(changes)}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Checking for access");
+try {
+  const { allowed } = await fgaClient.check({
+    user: "user:anne",
+    relation: "viewer",
+    object: "document:roadmap"
+  });
+  console.log(`Allowed: ${allowed}`);
+} catch (error) {
+  if (error instanceof FgaApiValidationError) {
+    console.log(`Failed due to ${error.apiErrorMessage}`);
+  } else {
+    console.error(`Error: ${error}`);
+    process.exit(1);
+  }
+}
+
+console.log("Checking for access with context");
+try {
+  const { allowed } = await fgaClient.check({
+    user: "user:anne",
+    relation: "viewer",
+    object: "document:roadmap",
+    context: {
+      ViewCount: 100
+    }
+  });
+  console.log(`Allowed: ${allowed}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Writing Assertions");
+try {
+  await fgaClient.writeAssertions([
+    {
+      user: "user:carl",
+      relation: "writer",
+      object: "document:budget",
+      expectation: true
+    },
+    {
+      user: "user:carl",
+      relation: "writer",
+      object: "document:roadmap",
+      expectation: false
+    }
+  ]);
+  console.log("Assertions Updated");
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Reading Assertions");
+try {
+  const { assertions} = await fgaClient.readAssertions();
+  console.log(`Assertions: ${JSON.stringify(assertions)}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log("Deleting Current Store");
+try {
+  await fgaClient.deleteStore();
+  console.log(`Deleted Store Count: ${store.id}`);
+} catch (error) {
+  console.error(`error: ${error}`);
+  process.exit(1);
+}

--- a/example/example1/package.json
+++ b/example/example1/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "example1",
+  "private": "true",
+  "version": "1.0.0",
+  "description": "A bare bones example of using the OpenFGA SDK",
+  "author": "OpenFGA",
+  "license": "Apache-2.0",
+  "scripts": {
+    "run-example": "node example1.mjs"
+  },
+  "dependencies": {
+    "@openfga/sdk": "^0.3.1"
+  },
+  "engines": {
+    "node": ">=16.13.0"
+  }
+}


### PR DESCRIPTION
## Description

Adds an example for the JS SDK that copies the structure of the other SDKs. I made the following choices here:

* Usage of ESM instead of CommonJS - Personal opinion that we should be moving to this in documentation
* Usage of top level await/mjs - Avoids having to use an async iiife to allow using async/await
	* I _think_ we could move to a `.js` file with a `type` field in the `package.json` of the example if desired
* No `package-lock` committed - It's just another file to maintain and keep in sync between the SDK repo and the generator repo, and realistically adds 0 benefit

These two choices are what primarily drove the require for the `>=16.13.0` (earliest 16 LTS) value in the examples `engines.node` field, although there is no check here so earlier versions will error with a potentially unhelpful error (is it worth adding a check?).

## References

Closes out #198
Generated from: https://github.com/openfga/sdk-generator/issues/305

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
