### PR TITLE
fix: use correct content type for token request

### DIFF
--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -144,6 +144,9 @@ export class Credentials {
           client_secret: clientCredentials.clientSecret,
           audience: clientCredentials.apiAudience,
           grant_type: "client_credentials",
+        },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
         }
       }, {
         maxRetry: 3,

--- a/tests/helpers/nocks.ts
+++ b/tests/helpers/nocks.ts
@@ -40,10 +40,12 @@ export const getNocks = ((nock: typeof Nock) => ({
     expiresIn = 300,
     statusCode = 200,
   ) => {
-    return nock(`https://${apiTokenIssuer}`).post("/oauth/token").reply(statusCode, {
-      access_token: accessToken,
-      expires_in: expiresIn,
-    });
+    return nock(`https://${apiTokenIssuer}`, { reqheaders: { "Content-Type": "application/x-www-form-urlencoded"} })
+      .post("/oauth/token")
+      .reply(statusCode, {
+        access_token: accessToken,
+        expires_in: expiresIn,
+      });
   },
   listStores: (
     basePath = defaultConfiguration.getBasePath(),


### PR DESCRIPTION
## Description

Moves the client to use `application/x-www-form-urlencoded` for the content type when making token requests per the spec.

In order to do this we set the header on the request and axios will serialize the `data` we provide for us

## References

Part of https://github.com/openfga/sdk-generator/issues/284
Generated from https://github.com/openfga/sdk-generator/issues/308

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
