### PR TITLE
release: v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.3.2
+
+### [0.3.1](https://github.com/openfga/js-sdk/compare/v0.3.1...v0.3.2) (2024-02-13)
+
+- feat: add example project
+- feat: add support for `apiUrl` configuration option and deprecate `apiScheme` and `apiHost`
+- fix: use correct content type for token request
+- fix: make body in `readChanges` optional
+
 ## v0.3.1
 
 ### [0.3.1](https://github.com/openfga/js-sdk/compare/v0.3.0...v0.3.1) (2024-01-26)

--- a/configuration.ts
+++ b/configuration.ts
@@ -21,7 +21,7 @@ const DEFAULT_MAX_RETRY = 15;
 // default minimum wait period in retry - but will backoff exponentially
 const DEFAULT_MIN_WAIT_MS = 100;
 
-const DEFAULT_USER_AGENT = "openfga-sdk js/0.3.1";
+const DEFAULT_USER_AGENT = "openfga-sdk js/0.3.2";
 
 export interface RetryParams {
   maxRetry?: number;
@@ -74,7 +74,7 @@ export class Configuration {
    * @type {string}
    * @memberof Configuration
    */
-  private static sdkVersion = "0.3.1";
+  private static sdkVersion = "0.3.2";
 
   /**
    * provide the full api URL (e.g. `https://api.fga.example`)

--- a/example/README.md
+++ b/example/README.md
@@ -28,7 +28,7 @@ Steps
 2. In the Example `package.json` change the `@openfga/sdk` dependency from a semver range like below
 ```json
 "dependencies": {
-    "@openfga/sdk": "^0.3.1"
+    "@openfga/sdk": "^0.3.2"
   }
 ```
 to a `file:` reference like below

--- a/example/example1/example1.mjs
+++ b/example/example1/example1.mjs
@@ -1,9 +1,9 @@
-import { Credentials, CredentialsMethod, FgaApiValidationError, OpenFgaClient, TypeName } from "@openfga/sdk";
+import { CredentialsMethod, FgaApiValidationError, OpenFgaClient, TypeName } from "@openfga/sdk";
 
 async function main () {
   let credentials;
   if (process.env.FGA_CLIENT_ID) {
-    credentials = new Credentials({
+    credentials = {
       method: CredentialsMethod.ClientCredentials,
       config: {
         clientId: process.env.FGA_CLIENT_ID,
@@ -11,7 +11,7 @@ async function main () {
         apiAudience: process.env.FGA_API_AUDIENCE,
         apiTokenIssuer: process.env.FGA_API_TOKEN_ISSUER
       }
-    });
+    };
   }
   
   const fgaClient = new OpenFgaClient({

--- a/example/example1/package.json
+++ b/example/example1/package.json
@@ -9,7 +9,7 @@
     "start": "node example1.mjs"
   },
   "dependencies": {
-    "@openfga/sdk": "^0.3.1"
+    "@openfga/sdk": "^0.3.2"
   },
   "engines": {
     "node": ">=16.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openfga/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openfga/sdk",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfga/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "JavaScript and Node.js SDK for OpenFGA",
   "author": "OpenFGA",
   "keywords": [


### PR DESCRIPTION
## Description

- feat: add example project
- feat: add support for `apiUrl` configuration option and deprecate `apiScheme` and `apiHost`
- fix: use correct content type for token request
- fix: make body in `readChanges` optional

Also copies across the change to the example project

## References


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
