### PR TITLE
 fix: resolve circular import

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,3 +16,5 @@ updates:
      dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "eslint"

--- a/.madgerc
+++ b/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -11,6 +11,7 @@
 .github/workflows/semgrep.yaml
 .gitignore
 .gitignore
+.madgerc
 .npmrc
 CHANGELOG.md
 CONTRIBUTING.md

--- a/common.ts
+++ b/common.ts
@@ -14,7 +14,7 @@
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { Configuration } from "./configuration";
-import { Credentials } from "./credentials";
+import type { Credentials } from "./credentials";
 import {
   FgaApiError,
   FgaApiInternalError,
@@ -180,15 +180,13 @@ export async function attemptHttpRequest<B, R>(
 /**
  * creates an axios request function
  */
-export const createRequestFunction = function (axiosArgs: RequestArgs, axiosInstance: AxiosInstance, configuration: Configuration, credentials?: Credentials) {
+export const createRequestFunction = function (axiosArgs: RequestArgs, axiosInstance: AxiosInstance, configuration: Configuration, credentials: Credentials) {
   configuration.isValid();
 
   const retryParams = axiosArgs.options?.retryParams ? axiosArgs.options?.retryParams : configuration.retryParams;
   const maxRetry:number = retryParams ? retryParams.maxRetry : 0;
   const minWaitInMs:number = retryParams ? retryParams.minWaitInMs : 0;
-  if (!credentials) {
-    credentials = Credentials.init(configuration);
-  }
+
   return async (axios: AxiosInstance = axiosInstance) : PromiseResult<any> => {
     await setBearerAuthToObject(axiosArgs.options.headers, credentials!);
 


### PR DESCRIPTION
## Description

Fixes the circular import being flagged by the new version of madge, and configures madge to ignore type imports

## References

Generated from https://github.com/openfga/sdk-generator/pull/344

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
