### PR TITLE
chore: Target ES2020 for compilation, remove unnecessary Promise based code

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -125,7 +125,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    check: async (storeId: string, body: CheckRequest, options: any = {}): Promise<RequestArgs> => {
+    check: (storeId: string, body: CheckRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("check", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -163,7 +163,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    createStore: async (body: CreateStoreRequest, options: any = {}): Promise<RequestArgs> => {
+    createStore: (body: CreateStoreRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'body' is not null or undefined
       assertParamExists("createStore", "body", body);
       const localVarPath = "/stores"
@@ -199,7 +199,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    deleteStore: async (storeId: string, options: any = {}): Promise<RequestArgs> => {
+    deleteStore: (storeId: string, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("deleteStore", "storeId", storeId);
       const localVarPath = "/stores/{store_id}"
@@ -233,7 +233,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    expand: async (storeId: string, body: ExpandRequest, options: any = {}): Promise<RequestArgs> => {
+    expand: (storeId: string, body: ExpandRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("expand", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -271,7 +271,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    getStore: async (storeId: string, options: any = {}): Promise<RequestArgs> => {
+    getStore: (storeId: string, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("getStore", "storeId", storeId);
       const localVarPath = "/stores/{store_id}"
@@ -305,7 +305,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    listObjects: async (storeId: string, body: ListObjectsRequest, options: any = {}): Promise<RequestArgs> => {
+    listObjects: (storeId: string, body: ListObjectsRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("listObjects", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -344,7 +344,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    listStores: async (pageSize?: number, continuationToken?: string, options: any = {}): Promise<RequestArgs> => {
+    listStores: (pageSize?: number, continuationToken?: string, options: any = {}): RequestArgs => {
       const localVarPath = "/stores"
             ;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -384,7 +384,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    listUsers: async (storeId: string, body: ListUsersRequest, options: any = {}): Promise<RequestArgs> => {
+    listUsers: (storeId: string, body: ListUsersRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("listUsers", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -423,7 +423,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    read: async (storeId: string, body: ReadRequest, options: any = {}): Promise<RequestArgs> => {
+    read: (storeId: string, body: ReadRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("read", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -462,7 +462,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    readAssertions: async (storeId: string, authorizationModelId: string, options: any = {}): Promise<RequestArgs> => {
+    readAssertions: (storeId: string, authorizationModelId: string, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("readAssertions", "storeId", storeId);
       // verify required parameter 'authorizationModelId' is not null or undefined
@@ -498,7 +498,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    readAuthorizationModel: async (storeId: string, id: string, options: any = {}): Promise<RequestArgs> => {
+    readAuthorizationModel: (storeId: string, id: string, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("readAuthorizationModel", "storeId", storeId);
       // verify required parameter 'id' is not null or undefined
@@ -535,7 +535,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    readAuthorizationModels: async (storeId: string, pageSize?: number, continuationToken?: string, options: any = {}): Promise<RequestArgs> => {
+    readAuthorizationModels: (storeId: string, pageSize?: number, continuationToken?: string, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("readAuthorizationModels", "storeId", storeId);
       const localVarPath = "/stores/{store_id}/authorization-models"
@@ -579,7 +579,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    readChanges: async (storeId: string, type?: string, pageSize?: number, continuationToken?: string, options: any = {}): Promise<RequestArgs> => {
+    readChanges: (storeId: string, type?: string, pageSize?: number, continuationToken?: string, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("readChanges", "storeId", storeId);
       const localVarPath = "/stores/{store_id}/changes"
@@ -625,7 +625,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    write: async (storeId: string, body: WriteRequest, options: any = {}): Promise<RequestArgs> => {
+    write: (storeId: string, body: WriteRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("write", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -665,7 +665,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    writeAssertions: async (storeId: string, authorizationModelId: string, body: WriteAssertionsRequest, options: any = {}): Promise<RequestArgs> => {
+    writeAssertions: (storeId: string, authorizationModelId: string, body: WriteAssertionsRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("writeAssertions", "storeId", storeId);
       // verify required parameter 'authorizationModelId' is not null or undefined
@@ -706,7 +706,7 @@ export const OpenFgaApiAxiosParamCreator = function (configuration: Configuratio
          * @param {*} [options] Override http request option.
          * @throws { FgaError }
          */
-    writeAuthorizationModel: async (storeId: string, body: WriteAuthorizationModelRequest, options: any = {}): Promise<RequestArgs> => {
+    writeAuthorizationModel: (storeId: string, body: WriteAuthorizationModelRequest, options: any = {}): RequestArgs => {
       // verify required parameter 'storeId' is not null or undefined
       assertParamExists("writeAuthorizationModel", "storeId", storeId);
       // verify required parameter 'body' is not null or undefined
@@ -756,7 +756,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async check(storeId: string, body: CheckRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<CheckResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.check(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.check(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "check",
         [attributeNames.requestStoreId]: storeId,
@@ -772,7 +772,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async createStore(body: CreateStoreRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<CreateStoreResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.createStore(body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.createStore(body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "createStore",
       });
@@ -785,7 +785,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async deleteStore(storeId: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<void>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteStore(storeId, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.deleteStore(storeId, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "deleteStore",
         [attributeNames.requestStoreId]: storeId,
@@ -800,7 +800,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async expand(storeId: string, body: ExpandRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ExpandResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.expand(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.expand(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "expand",
         [attributeNames.requestModelId]: body.authorization_model_id,
@@ -815,7 +815,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async getStore(storeId: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<GetStoreResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getStore(storeId, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.getStore(storeId, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "getStore",
         [attributeNames.requestStoreId]: storeId,
@@ -830,7 +830,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async listObjects(storeId: string, body: ListObjectsRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ListObjectsResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.listObjects(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.listObjects(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "listObjects",
         [attributeNames.requestStoreId]: storeId,
@@ -847,7 +847,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async listStores(pageSize?: number, continuationToken?: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ListStoresResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.listStores(pageSize, continuationToken, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.listStores(pageSize, continuationToken, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "listStores",
       });
@@ -861,7 +861,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async listUsers(storeId: string, body: ListUsersRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ListUsersResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.listUsers(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.listUsers(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "listUsers",
         [attributeNames.requestStoreId]: storeId,
@@ -877,7 +877,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async read(storeId: string, body: ReadRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.read(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.read(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "read",
         [attributeNames.requestStoreId]: storeId,
@@ -892,7 +892,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async readAssertions(storeId: string, authorizationModelId: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadAssertionsResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.readAssertions(storeId, authorizationModelId, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.readAssertions(storeId, authorizationModelId, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "readAssertions",
         [attributeNames.requestStoreId]: storeId,
@@ -908,7 +908,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async readAuthorizationModel(storeId: string, id: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadAuthorizationModelResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.readAuthorizationModel(storeId, id, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.readAuthorizationModel(storeId, id, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "readAuthorizationModel",
         [attributeNames.requestStoreId]: storeId,
@@ -924,7 +924,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async readAuthorizationModels(storeId: string, pageSize?: number, continuationToken?: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadAuthorizationModelsResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.readAuthorizationModels(storeId, pageSize, continuationToken, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.readAuthorizationModels(storeId, pageSize, continuationToken, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "readAuthorizationModels",
         [attributeNames.requestStoreId]: storeId,
@@ -941,7 +941,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async readChanges(storeId: string, type?: string, pageSize?: number, continuationToken?: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadChangesResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.readChanges(storeId, type, pageSize, continuationToken, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.readChanges(storeId, type, pageSize, continuationToken, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "readChanges",
         [attributeNames.requestStoreId]: storeId,
@@ -956,7 +956,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async write(storeId: string, body: WriteRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<object>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.write(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.write(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "write",
         [attributeNames.requestStoreId]: storeId,
@@ -973,7 +973,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async writeAssertions(storeId: string, authorizationModelId: string, body: WriteAssertionsRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<void>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.writeAssertions(storeId, authorizationModelId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.writeAssertions(storeId, authorizationModelId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "writeAssertions",
         [attributeNames.requestStoreId]: storeId,
@@ -989,7 +989,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          * @throws { FgaError }
          */
     async writeAuthorizationModel(storeId: string, body: WriteAuthorizationModelRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<WriteAuthorizationModelResponse>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.writeAuthorizationModel(storeId, body, options);
+      const localVarAxiosArgs = localVarAxiosParamCreator.writeAuthorizationModel(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "writeAuthorizationModel",
         [attributeNames.requestStoreId]: storeId,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es6",
+    "target": "es2020",
     "module": "commonjs",
     "noImplicitAny": true,
     "strict": true,


### PR DESCRIPTION
This specifically means that TypeScript will no longer transpile async/await for us which means
the generated code is easier to work with

## Description

I've spent some time in the codebase this week working on the metrics pieces and just wanted to suggest we make these two changes, the first to make debugging the code easier and the second just for correctness sake.

* 71efbf1e57ed5a1c85c8254362ac4e7daeef21b7 - use es2020 for target as supported environments all support this
	* This specifically means that TypeScript will no longer transpile async/await for us which means
the generated code is easier to work with	
* d8415d176d84ea25b9014179393847afea7107d8 - remove unnecessary async functions
	* The code here doesn't need to be Promise based so making it so means we're introducing a
(tiny most likely) hit to performance by using it when it's not required
	* I don't believe `OpenFgaApiAxiosParamCreator` is an intended part of our public interface (just there because we export it) so this shouldn't be classed as a breaking change imo.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
