### PR TITLE
feat: add opentelemetry metrics reporting

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -22,7 +22,8 @@ import {
   createRequestFunction,
   RequestArgs,
   CallResult,
-  PromiseResult
+  PromiseResult,
+  attributeNames
 } from "./common";
 import { Configuration } from "./configuration";
 import { Credentials } from "./credentials";
@@ -756,7 +757,11 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async check(storeId: string, body: CheckRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<CheckResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.check(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "check",
+        [attributeNames.user]: body.tuple_key.user
+      });
     },
     /**
          * Create a unique OpenFGA store which will be used to store authorization models and relationship tuples.
@@ -767,7 +772,9 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async createStore(body: CreateStoreRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<CreateStoreResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createStore(body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, { 
+        [attributeNames.requestMethod]: "createStore"
+      });
     },
     /**
          * Delete an OpenFGA store. This does not delete the data associated with the store, like tuples or authorization models.
@@ -790,7 +797,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async expand(storeId: string, body: ExpandRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ExpandResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.expand(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestMethod]: "expand"
+      });
     },
     /**
          * Returns an OpenFGA store by its identifier
@@ -801,7 +811,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async getStore(storeId: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<GetStoreResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getStore(storeId, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "getStore"
+      });
     },
     /**
          * The ListObjects API returns a list of all the objects of the given type that the user has a relation with.  To arrive at a result, the API uses: an authorization model, explicit tuples written through the Write API, contextual tuples present in the request, and implicit tuples that exist by virtue of applying set theory (such as `document:2021-budget#viewer@document:2021-budget#viewer`; the set of users who are viewers of `document:2021-budget` are the set of users who are the viewers of `document:2021-budget`). An `authorization_model_id` may be specified in the body. If it is not specified, the latest authorization model ID will be used. It is strongly recommended to specify authorization model id for better performance. You may also specify `contextual_tuples` that will be treated as regular tuples. Each of these tuples may have an associated `condition`. You may also provide a `context` object that will be used to evaluate the conditioned tuples in the system. It is strongly recommended to provide a value for all the input parameters of all the conditions, to ensure that all tuples be evaluated correctly. The response will contain the related objects in an array in the \"objects\" field of the response and they will be strings in the object format `<type>:<id>` (e.g. \"document:roadmap\"). The number of objects in the response array will be limited by the execution timeout specified in the flag OPENFGA_LIST_OBJECTS_DEADLINE and by the upper bound specified in the flag OPENFGA_LIST_OBJECTS_MAX_RESULTS, whichever is hit first. The objects given will not be sorted, and therefore two identical calls can give a given different set of objects.
@@ -813,7 +826,11 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async listObjects(storeId: string, body: ListObjectsRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ListObjectsResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.listObjects(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "listObjects",
+        [attributeNames.user]: body.user
+      });
     },
     /**
          * Returns a paginated list of OpenFGA stores and a continuation token to get additional stores. The continuation token will be empty if there are no more stores. 
@@ -825,7 +842,9 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async listStores(pageSize?: number, continuationToken?: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ListStoresResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.listStores(pageSize, continuationToken, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, { 
+        [attributeNames.requestMethod]: "listStores"
+      });
     },
     /**
          * The ListUsers API returns a list of all the users of a specific type that have a relation to a given object.  This API is available in an experimental capacity and can be enabled with the `--experimentals enable-list-users` flag.  To arrive at a result, the API uses: an authorization model, explicit tuples written through the Write API, contextual tuples present in the request, and implicit tuples that exist by virtue of applying set theory (such as `document:2021-budget#viewer@document:2021-budget#viewer`; the set of users who are viewers of `document:2021-budget` are the set of users who are the viewers of `document:2021-budget`). An `authorization_model_id` may be specified in the body. If it is not specified, the latest authorization model ID will be used. It is strongly recommended to specify authorization model id for better performance. You may also specify `contextual_tuples` that will be treated as regular tuples. Each of these tuples may have an associated `condition`. You may also provide a `context` object that will be used to evaluate the conditioned tuples in the system. It is strongly recommended to provide a value for all the input parameters of all the conditions, to ensure that all tuples be evaluated correctly. The response will contain the related users in an array in the \"users\" field of the response. These results may include specific objects, usersets  or type-bound public access. Each of these types of results is encoded in its own type and not represented as a string.In cases where a type-bound public acces result is returned (e.g. `user:*`), it cannot be inferred that all subjects of that type have a relation to the object; it is possible that negations exist and checks should still be queried on individual subjects to ensure access to that document.The number of users in the response array will be limited by the execution timeout specified in the flag OPENFGA_LIST_USERS_DEADLINE and by the upper bound specified in the flag OPENFGA_LIST_USERS_MAX_RESULTS, whichever is hit first. The returned users will not be sorted, and therefore two identical calls may yield different sets of users.
@@ -837,7 +856,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async listUsers(storeId: string, body: ListUsersRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ListUsersResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.listUsers(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "listUsers"
+      });
     },
     /**
          * The Read API will return the tuples for a certain store that match a query filter specified in the body of the request.  The API doesn\'t guarantee order by any field.  It is different from the `/stores/{store_id}/expand` API in that it only returns relationship tuples that are stored in the system and satisfy the query.  In the body: 1. `tuple_key` is optional. If not specified, it will return all tuples in the store. 2. `tuple_key.object` is mandatory if `tuple_key` is specified. It can be a full object (e.g., `type:object_id`) or type only (e.g., `type:`). 3. `tuple_key.user` is mandatory if tuple_key is specified in the case the `tuple_key.object` is a type only. ## Examples ### Query for all objects in a type definition To query for all objects that `user:bob` has `reader` relationship in the `document` type definition, call read API with body of ```json {  \"tuple_key\": {      \"user\": \"user:bob\",      \"relation\": \"reader\",      \"object\": \"document:\"   } } ``` The API will return tuples and a continuation token, something like ```json {   \"tuples\": [     {       \"key\": {         \"user\": \"user:bob\",         \"relation\": \"reader\",         \"object\": \"document:2021-budget\"       },       \"timestamp\": \"2021-10-06T15:32:11.128Z\"     }   ],   \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\" } ``` This means that `user:bob` has a `reader` relationship with 1 document `document:2021-budget`. Note that this API, unlike the List Objects API, does not evaluate the tuples in the store. The continuation token will be empty if there are no more tuples to query. ### Query for all stored relationship tuples that have a particular relation and object To query for all users that have `reader` relationship with `document:2021-budget`, call read API with body of  ```json {   \"tuple_key\": {      \"object\": \"document:2021-budget\",      \"relation\": \"reader\"    } } ``` The API will return something like  ```json {   \"tuples\": [     {       \"key\": {         \"user\": \"user:bob\",         \"relation\": \"reader\",         \"object\": \"document:2021-budget\"       },       \"timestamp\": \"2021-10-06T15:32:11.128Z\"     }   ],   \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\" } ``` This means that `document:2021-budget` has 1 `reader` (`user:bob`).  Note that, even if the model said that all `writers` are also `readers`, the API will not return writers such as `user:anne` because it only returns tuples and does not evaluate them. ### Query for all users with all relationships for a particular document To query for all users that have any relationship with `document:2021-budget`, call read API with body of  ```json {   \"tuple_key\": {       \"object\": \"document:2021-budget\"    } } ``` The API will return something like  ```json {   \"tuples\": [     {       \"key\": {         \"user\": \"user:anne\",         \"relation\": \"writer\",         \"object\": \"document:2021-budget\"       },       \"timestamp\": \"2021-10-05T13:42:12.356Z\"     },     {       \"key\": {         \"user\": \"user:bob\",         \"relation\": \"reader\",         \"object\": \"document:2021-budget\"       },       \"timestamp\": \"2021-10-06T15:32:11.128Z\"     }   ],   \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\" } ``` This means that `document:2021-budget` has 1 `reader` (`user:bob`) and 1 `writer` (`user:anne`). 
@@ -849,7 +871,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async read(storeId: string, body: ReadRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.read(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "read"
+      });
     },
     /**
          * The ReadAssertions API will return, for a given authorization model id, all the assertions stored for it. An assertion is an object that contains a tuple key, and the expectation of whether a call to the Check API of that tuple key will return true or false. 
@@ -861,7 +886,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async readAssertions(storeId: string, authorizationModelId: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadAssertionsResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.readAssertions(storeId, authorizationModelId, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "readAssertions"
+      });
     },
     /**
          * The ReadAuthorizationModel API returns an authorization model by its identifier. The response will return the authorization model for the particular version.  ## Example To retrieve the authorization model with ID `01G5JAVJ41T49E9TT3SKVS7X1J` for the store, call the GET authorization-models by ID API with `01G5JAVJ41T49E9TT3SKVS7X1J` as the `id` path parameter.  The API will return: ```json {   \"authorization_model\":{     \"id\":\"01G5JAVJ41T49E9TT3SKVS7X1J\",     \"type_definitions\":[       {         \"type\":\"user\"       },       {         \"type\":\"document\",         \"relations\":{           \"reader\":{             \"union\":{               \"child\":[                 {                   \"this\":{}                 },                 {                   \"computedUserset\":{                     \"object\":\"\",                     \"relation\":\"writer\"                   }                 }               ]             }           },           \"writer\":{             \"this\":{}           }         }       }     ]   } } ``` In the above example, there are 2 types (`user` and `document`). The `document` type has 2 relations (`writer` and `reader`).
@@ -873,7 +901,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async readAuthorizationModel(storeId: string, id: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadAuthorizationModelResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.readAuthorizationModel(storeId, id, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "readAuthorizationModel"
+      });
     },
     /**
          * The ReadAuthorizationModels API will return all the authorization models for a certain store. OpenFGA\'s response will contain an array of all authorization models, sorted in descending order of creation.  ## Example Assume that a store\'s authorization model has been configured twice. To get all the authorization models that have been created in this store, call GET authorization-models. The API will return a response that looks like: ```json {   \"authorization_models\": [     {       \"id\": \"01G50QVV17PECNVAHX1GG4Y5NC\",       \"type_definitions\": [...]     },     {       \"id\": \"01G4ZW8F4A07AKQ8RHSVG9RW04\",       \"type_definitions\": [...]     },   ],   \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\" } ``` If there are no more authorization models available, the `continuation_token` field will be empty ```json {   \"authorization_models\": [     {       \"id\": \"01G50QVV17PECNVAHX1GG4Y5NC\",       \"type_definitions\": [...]     },     {       \"id\": \"01G4ZW8F4A07AKQ8RHSVG9RW04\",       \"type_definitions\": [...]     },   ],   \"continuation_token\": \"\" } ``` 
@@ -886,7 +917,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async readAuthorizationModels(storeId: string, pageSize?: number, continuationToken?: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadAuthorizationModelsResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.readAuthorizationModels(storeId, pageSize, continuationToken, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "readAuthorizationModels"
+      });
     },
     /**
          * The ReadChanges API will return a paginated list of tuple changes (additions and deletions) that occurred in a given store, sorted by ascending time. The response will include a continuation token that is used to get the next set of changes. If there are no changes after the provided continuation token, the same token will be returned in order for it to be used when new changes are recorded. If the store never had any tuples added or removed, this token will be empty. You can use the `type` parameter to only get the list of tuple changes that affect objects of that type. When reading a write tuple change, if it was conditioned, the condition will be returned. When reading a delete tuple change, the condition will NOT be returned regardless of whether it was originally conditioned or not. 
@@ -900,7 +934,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async readChanges(storeId: string, type?: string, pageSize?: number, continuationToken?: string, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<ReadChangesResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.readChanges(storeId, type, pageSize, continuationToken, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "readChanges"
+      });
     },
     /**
          * The Write API will transactionally update the tuples for a certain store. Tuples and type definitions allow OpenFGA to determine whether a relationship exists between an object and an user. In the body, `writes` adds new tuples and `deletes` removes existing tuples. When deleting a tuple, any `condition` specified with it is ignored. The API is not idempotent: if, later on, you try to add the same tuple key (even if the `condition` is different), or if you try to delete a non-existing tuple, it will throw an error. The API will not allow you to write tuples such as `document:2021-budget#viewer@document:2021-budget#viewer`, because they are implicit. An `authorization_model_id` may be specified in the body. If it is, it will be used to assert that each written tuple (not deleted) is valid for the model specified. If it is not specified, the latest authorization model ID will be used. ## Example ### Adding relationships To add `user:anne` as a `writer` for `document:2021-budget`, call write API with the following  ```json {   \"writes\": {     \"tuple_keys\": [       {         \"user\": \"user:anne\",         \"relation\": \"writer\",         \"object\": \"document:2021-budget\"       }     ]   },   \"authorization_model_id\": \"01G50QVV17PECNVAHX1GG4Y5NC\" } ``` ### Removing relationships To remove `user:bob` as a `reader` for `document:2021-budget`, call write API with the following  ```json {   \"deletes\": {     \"tuple_keys\": [       {         \"user\": \"user:bob\",         \"relation\": \"reader\",         \"object\": \"document:2021-budget\"       }     ]   } } ``` 
@@ -912,7 +949,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async write(storeId: string, body: WriteRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<object>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.write(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "write"
+      });
     },
     /**
          * The WriteAssertions API will upsert new assertions for an authorization model id, or overwrite the existing ones. An assertion is an object that contains a tuple key, and the expectation of whether a call to the Check API of that tuple key will return true or false. 
@@ -925,7 +965,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async writeAssertions(storeId: string, authorizationModelId: string, body: WriteAssertionsRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<void>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.writeAssertions(storeId, authorizationModelId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "writeAssertions"
+      });
     },
     /**
          * The WriteAuthorizationModel API will add a new authorization model to a store. Each item in the `type_definitions` array is a type definition as specified in the field `type_definition`. The response will return the authorization model\'s ID in the `id` field.  ## Example To add an authorization model with `user` and `document` type definitions, call POST authorization-models API with the body:  ```json {   \"type_definitions\":[     {       \"type\":\"user\"     },     {       \"type\":\"document\",       \"relations\":{         \"reader\":{           \"union\":{             \"child\":[               {                 \"this\":{}               },               {                 \"computedUserset\":{                   \"object\":\"\",                   \"relation\":\"writer\"                 }               }             ]           }         },         \"writer\":{           \"this\":{}         }       }     }   ] } ``` OpenFGA\'s response will include the version id for this authorization model, which will look like  ``` {\"authorization_model_id\": \"01G50QVV17PECNVAHX1GG4Y5NC\"} ``` 
@@ -937,7 +980,10 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
          */
     async writeAuthorizationModel(storeId: string, body: WriteAuthorizationModelRequest, options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<WriteAuthorizationModelResponse>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.writeAuthorizationModel(storeId, body, options);
-      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
+        [attributeNames.requestStoreId]: storeId, 
+        [attributeNames.requestMethod]: "writeAuthorizationModel"
+      });
     },
   };
 };

--- a/api.ts
+++ b/api.ts
@@ -22,9 +22,8 @@ import {
   createRequestFunction,
   RequestArgs,
   CallResult,
-  PromiseResult,
-  attributeNames
-} from "./common";
+  PromiseResult} from "./common";
+import { attributeNames } from "./telemetry";
 import { Configuration } from "./configuration";
 import { Credentials } from "./credentials";
 import { assertParamExists } from "./validation";

--- a/common.ts
+++ b/common.ts
@@ -12,12 +12,11 @@
 
 
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
-import { Attributes, metrics } from "@opentelemetry/api";
-import { SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_STATUS_CODE } from "@opentelemetry/semantic-conventions";
+import { metrics } from "@opentelemetry/api";
 
 
 import { Configuration } from "./configuration";
-import { AuthCredentialsConfig, CredentialsMethod, type Credentials } from "./credentials";
+import type { Credentials } from "./credentials";
 import {
   FgaApiError,
   FgaApiInternalError,
@@ -28,6 +27,7 @@ import {
   FgaError
 } from "./errors";
 import { setNotEnumerableProperty } from "./utils";
+import { buildAttributes } from "./telemetry";
 
 const meter = metrics.getMeter("@openfga/sdk", "0.5.0");
 const durationHist = meter.createHistogram("fga-client.request.duration", {
@@ -231,55 +231,3 @@ export const createRequestFunction = function (axiosArgs: RequestArgs, axiosInst
   };
 };
 
-/**
- * Builds an object of attributes that can be used to report alongside an OpenTelemetry metric event.
- * 
- * @param response - The Axios response object, used to add data like HTTP status, host, method, and headers.
- * @param credentials - The credentials object, used to add data like the ClientID when using ClientCredentials.
- * @param methodAttributes - Extra attributes that the method (i.e. check, listObjects) wishes to have included. Any custom attributes should use the common names.
- * @returns {Attributes}
- */
-export const buildAttributes = function buildAttributes(response: AxiosResponse<unknown, any>|undefined, credentials: AuthCredentialsConfig, methodAttributes: Record<string, any> = {}): Attributes {
-  const attributes: Attributes = {
-    ...methodAttributes,
-  };
-
-  if (response?.status) {
-    attributes[SEMATTRS_HTTP_STATUS_CODE] = response.status;
-  }
-  
-  if (response?.request) {
-    attributes[SEMATTRS_HTTP_METHOD] = response.request.method;
-    attributes[SEMATTRS_HTTP_HOST] = response.request.host;
-  }
-
-  if (response?.headers) {
-    const modelId = response.headers["openfga-authorization-model-id"];
-    if (modelId !== undefined) {
-      attributes[attributeNames.responseModelId] = modelId;
-    }
-  }
-
-  if (credentials?.method === CredentialsMethod.ClientCredentials) {
-    attributes[attributeNames.requestClientId] = credentials.config.clientId;
-  } 
-
-  return attributes;
-};
-
-/**
- * Common attribute names
- */
-export const attributeNames = {
-  // Attributes associated with the request made
-  requestModelId: "fga-client.request.model_id",
-  requestMethod: "fga-client.request.method",
-  requestStoreId: "fga-client.request.store_id",
-  requestClientId: "fga-client.request.client_id",
-
-  // Attributes associated with the response
-  responseModelId: "fga-client.response.model_id",
-
-  // Attributes associated with specific actions
-  user: "fga-client.user"
-};

--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -15,12 +15,14 @@ import globalAxios, { AxiosInstance } from "axios";
 
 import { assertParamExists, isWellFormedUriString } from "../validation";
 import { FgaApiAuthenticationError, FgaApiError, FgaError, FgaValidationError } from "../errors";
-import { attemptHttpRequest } from "../common";
+import { attemptHttpRequest, buildAttributes } from "../common";
 import { ApiTokenConfig, AuthCredentialsConfig, ClientCredentialsConfig, CredentialsMethod } from "./types";
+import { Counter, metrics } from "@opentelemetry/api";
 
 export class Credentials {
   private accessToken?: string;
   private accessTokenExpiryDate?: Date;
+  private tokenCounter?: Counter;
 
   public static init(configuration: { credentials: AuthCredentialsConfig }): Credentials {
     return new Credentials(configuration.credentials);
@@ -48,7 +50,11 @@ export class Credentials {
         }
       }
       break;
-    case CredentialsMethod.ClientCredentials:
+    case CredentialsMethod.ClientCredentials: {
+      const meter = metrics.getMeter("@openfga/sdk", "0.5.0");
+      this.tokenCounter = meter.createCounter("fga-client.credentials.request");
+      break;
+    }
     case CredentialsMethod.None:
     default:
       break;
@@ -115,7 +121,6 @@ export class Credentials {
       if (this.accessToken && (!this.accessTokenExpiryDate || this.accessTokenExpiryDate > new Date())) {
         return this.accessToken;
       }
-
       return this.refreshAccessToken();
     }
   }
@@ -126,7 +131,6 @@ export class Credentials {
    */
   private async refreshAccessToken() {
     const clientCredentials = (this.authConfig as { method: CredentialsMethod.ClientCredentials; config: ClientCredentialsConfig })?.config;
-
     try {
       const response = await attemptHttpRequest<{
           client_id: string,
@@ -157,7 +161,7 @@ export class Credentials {
         this.accessToken = response.data.access_token;
         this.accessTokenExpiryDate = new Date(Date.now() + response.data.expires_in * 1000);
       }
-
+      this.tokenCounter?.add(1, buildAttributes(response, this.authConfig));
       return this.accessToken;
     } catch (err: unknown) {
       if (err instanceof FgaApiError) {

--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -15,7 +15,8 @@ import globalAxios, { AxiosInstance } from "axios";
 
 import { assertParamExists, isWellFormedUriString } from "../validation";
 import { FgaApiAuthenticationError, FgaApiError, FgaError, FgaValidationError } from "../errors";
-import { attemptHttpRequest, buildAttributes } from "../common";
+import { attemptHttpRequest } from "../common";
+import { buildAttributes } from "../telemetry";
 import { ApiTokenConfig, AuthCredentialsConfig, ClientCredentialsConfig, CredentialsMethod } from "./types";
 import { Counter, metrics } from "@opentelemetry/api";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,11 @@
   "packages": {
     "": {
       "name": "@openfga/sdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/semantic-conventions": "^1.25.0",
         "axios": "^1.6.8",
         "tiny-async-pool": "^2.1.0"
       },
@@ -1301,6 +1303,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6011,6 +6029,16 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint:fix": "eslint . --ext .ts --fix"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.25.0",
     "axios": "^1.6.8",
     "tiny-async-pool": "^2.1.0"
   },

--- a/telemetry.ts
+++ b/telemetry.ts
@@ -1,0 +1,58 @@
+import { AxiosResponse } from "axios";
+import { Attributes } from "@opentelemetry/api";
+import { SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_STATUS_CODE } from "@opentelemetry/semantic-conventions";
+import { AuthCredentialsConfig, CredentialsMethod } from "./credentials/types";
+
+/**
+ * Builds an object of attributes that can be used to report alongside an OpenTelemetry metric event.
+ *
+ * @param response - The Axios response object, used to add data like HTTP status, host, method, and headers.
+ * @param credentials - The credentials object, used to add data like the ClientID when using ClientCredentials.
+ * @param methodAttributes - Extra attributes that the method (i.e. check, listObjects) wishes to have included. Any custom attributes should use the common names.
+ * @returns {Attributes}
+ */
+
+export const buildAttributes = function buildAttributes(response: AxiosResponse<unknown, any> | undefined, credentials: AuthCredentialsConfig, methodAttributes: Record<string, any> = {}): Attributes {
+  const attributes: Attributes = {
+    ...methodAttributes,
+  };
+
+  if (response?.status) {
+    attributes[SEMATTRS_HTTP_STATUS_CODE] = response.status;
+  }
+
+  if (response?.request) {
+    attributes[SEMATTRS_HTTP_METHOD] = response.request.method;
+    attributes[SEMATTRS_HTTP_HOST] = response.request.host;
+  }
+
+  if (response?.headers) {
+    const modelId = response.headers["openfga-authorization-model-id"];
+    if (modelId !== undefined) {
+      attributes[attributeNames.responseModelId] = modelId;
+    }
+  }
+
+  if (credentials?.method === CredentialsMethod.ClientCredentials) {
+    attributes[attributeNames.requestClientId] = credentials.config.clientId;
+  }
+
+  return attributes;
+};
+/**
+ * Common attribute names
+ */
+
+export const attributeNames = {
+  // Attributes associated with the request made
+  requestModelId: "fga-client.request.model_id",
+  requestMethod: "fga-client.request.method",
+  requestStoreId: "fga-client.request.store_id",
+  requestClientId: "fga-client.request.client_id",
+
+  // Attributes associated with the response
+  responseModelId: "fga-client.response.model_id",
+
+  // Attributes associated with specific actions
+  user: "fga-client.user"
+};


### PR DESCRIPTION
## Description

Introduces OpenTelemetry metrics reporting into the SDK for specific actions, we're intentionally starting with only a few metric events that we can then grow over time.

We don't have any formal documentation for this currently, we'll write this as we roll it out across all SDKs, so here is a summary of the events and the associated attributes:

| Metric Name                     | Type      | Description                                                                     |
|---------------------------------|-----------|---------------------------------------------------------------------------------|
| `fga-client.request.duration`   | Histogram | The total request time for FGA requests                                         |
| `fga-client.query.duration`     | Histogram | The amount of time the FGA server took to process the request                   |
|` fga-client.credentials.request`| Counter   | The total number of times a new token was requested when using ClientCredentials|


| Attribute Name                 |  Type     | Description                                                                         |
|--------------------------------|----------|-------------------------------------------------------------------------------------|
| `fga-client.response.model_id` | `string` | The authorization model ID that the FGA server used                                 |
| `fga-client.request.method`    | `string` | The FGA method/action that was performed                                            |
| `fga-client.request.store_id`  | `string` | The store ID that was sent as part of the request                                   |
| `fga-client.request.model_id` | `string` | The authorization model ID that was sent as part of the request, if any                    |
| `fga-client.request.client_id` | `string` | The client ID associated with the request, if any  |
| `fga-client.user`              | `string` | The user that is associated with the action of the request for check and list users |
| `http.status_code `            | `int`    | The status code of the response                                                     |
| `http.method`                  | `string` | The HTTP method for the request                                                     |
| `http.host`                    | `string` | Host identifier of the origin the request was sent to                               |

We're implementing this using the `@opentelemetry/api` which means that all actions will be a no-op unless a `@opentelemetry/sdk-node` (or equivalent) instance is configured within an application. This is currently in draft as we work through the implementation across SDKs but we're looking for any feedback folks may have!

## References

Closes #108

## Review Checklist
- [ x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected