### PR TITLE
fix(metrics): add missing request model id attribute

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -760,6 +760,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "check",
         [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestModelId]: body.authorization_model_id,
         [attributeNames.user]: body.tuple_key.user
       });
     },
@@ -802,6 +803,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = await localVarAxiosParamCreator.expand(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "expand",
+        [attributeNames.requestModelId]: body.authorization_model_id,
         [attributeNames.requestStoreId]: storeId,
       });
     },
@@ -832,6 +834,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "listObjects",
         [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestModelId]: body.authorization_model_id,
         [attributeNames.user]: body.user
       });
     },
@@ -862,6 +865,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "listUsers",
         [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestModelId]: body.authorization_model_id,
       });
     },
     /**
@@ -892,6 +896,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "readAssertions",
         [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestModelId]: authorizationModelId,
       });
     },
     /**
@@ -955,6 +960,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "write",
         [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestModelId]: body.authorization_model_id,
       });
     },
     /**
@@ -971,6 +977,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [attributeNames.requestMethod]: "writeAssertions",
         [attributeNames.requestStoreId]: storeId,
+        [attributeNames.requestModelId]: authorizationModelId,
       });
     },
     /**


### PR DESCRIPTION
## Description

When generating the patch I overlooked including the fga-client.request.model_id attribute, this corrects that mistake and includes the model id when it is included in the request.


## References

https://github.com/openfga/sdk-generator/pull/388

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
