### PR TITLE
feat: support usage of the consistency option

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -42,6 +42,7 @@ import {
   Condition,
   ConditionMetadata,
   ConditionParamTypeRef,
+  ConsistencyPreference,
   ContextualTupleKeys,
   CreateStoreRequest,
   CreateStoreResponse,

--- a/apiModel.ts
+++ b/apiModel.ts
@@ -158,7 +158,15 @@ export interface CheckRequest {
      * @memberof CheckRequest
      */
     context?: object;
+    /**
+     * 
+     * @type {ConsistencyPreference}
+     * @memberof CheckRequest
+     */
+    consistency?: ConsistencyPreference;
 }
+
+
 /**
  * 
  * @export
@@ -286,6 +294,18 @@ export interface ConditionParamTypeRef {
     generic_types?: Array<ConditionParamTypeRef>;
 }
 
+
+/**
+ * - UNSPECIFIED: Default if not set. Behavior will be the same as MINIMIZE_LATENCY  - MINIMIZE_LATENCY: Minimize latency at the potential expense of lower consistency.  - HIGHER_CONSISTENCY: Prefer higher consistency, at the potential expense of increased latency.
+ * @export
+ * @enum {string}
+ */
+
+export enum ConsistencyPreference {
+    Unspecified = 'UNSPECIFIED',
+    MinimizeLatency = 'MINIMIZE_LATENCY',
+    HigherConsistency = 'HIGHER_CONSISTENCY'
+}
 
 /**
  * 
@@ -438,7 +458,15 @@ export interface ExpandRequest {
      * @memberof ExpandRequest
      */
     authorization_model_id?: string;
+    /**
+     * 
+     * @type {ConsistencyPreference}
+     * @memberof ExpandRequest
+     */
+    consistency?: ConsistencyPreference;
 }
+
+
 /**
  * 
  * @export
@@ -635,7 +663,15 @@ export interface ListObjectsRequest {
      * @memberof ListObjectsRequest
      */
     context?: object;
+    /**
+     * 
+     * @type {ConsistencyPreference}
+     * @memberof ListObjectsRequest
+     */
+    consistency?: ConsistencyPreference;
 }
+
+
 /**
  * 
  * @export
@@ -710,7 +746,15 @@ export interface ListUsersRequest {
      * @memberof ListUsersRequest
      */
     context?: object;
+    /**
+     * 
+     * @type {ConsistencyPreference}
+     * @memberof ListUsersRequest
+     */
+    consistency?: ConsistencyPreference;
 }
+
+
 /**
  * 
  * @export
@@ -956,7 +1000,15 @@ export interface ReadRequest {
      * @memberof ReadRequest
      */
     continuation_token?: string;
+    /**
+     * 
+     * @type {ConsistencyPreference}
+     * @memberof ReadRequest
+     */
+    consistency?: ConsistencyPreference;
 }
+
+
 /**
  * 
  * @export


### PR DESCRIPTION
## Description

This is an initial attempt at introducing support for the experimental consistency option in the relevant APIs, this is supported on the following APIs:

- Check
- List Users
- List Objects + Streamed List Objects
- Expand
- Read

And the following SDK methods

- listRelations
- batchCheck

When introducing this option to the `OpenFGAClient` class, we decided that this option fits better in the `options` object as opposed to the `request` object as it's more of an "override" choice akin to the existing model ID and store ID.

So the usage looks like so

```js
const { allowed } = await fgaClient.check({
  user: "user:anne",
  relation: "viewer",
  object: "document:roadmap",
}, { consistency: ConsistencyPreference.HigherConsistency });
```

I think there is a question around the correct usage for `batchCheck`, in that instance should the consistency choice be per check or for the entire `batchCheck`, currently we have it for the entire `batchCheck` but personally I don't think this is ideal.

```js
await fgaClient.batchCheck([{
  user: "user:anne",
  relation: "viewer",
  object: "document:roadmap",
}], { consistency: ConsistencyPreference.HigherConsistency });
```


## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
