### PR TITLE
feat: support custom path in apiTokenIssuer

### DIFF
--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -133,7 +133,10 @@ export class Credentials {
    */
   private async refreshAccessToken() {
     const clientCredentials = (this.authConfig as { method: CredentialsMethod.ClientCredentials; config: ClientCredentialsConfig })?.config;
-
+    const url = clientCredentials.apiTokenIssuer.includes('/')
+      ? `https://${clientCredentials.apiTokenIssuer}`
+      : `https://${clientCredentials.apiTokenIssuer}/oauth/token`;
+    
     try {
       const response = await attemptHttpRequest<{
           client_id: string,
@@ -144,7 +147,7 @@ export class Credentials {
         access_token: string,
         expires_in: number,
       }>({
-        url: `https://${clientCredentials.apiTokenIssuer}/oauth/token`,
+        url: url,
         method: "post",
         data: {
           client_id: clientCredentials.clientId,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR modifies the refreshAccessToken method to conditionally append the /oauth/token endpoint to the apiTokenIssuer only when the apiTokenIssuer does not include its own path. This ensures that the URL is correctly formed whether the issuer contains a custom path or is just a domain.

## References

Closes #141 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev)
 - [x] The correct base branch is being used, if not main
- [ ] I have added tests to validate that the change in functionality is working as expected
