### PR TITLE
fix: error correctly if apiUrl is not provided

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -53,7 +53,7 @@ import {
   generateRandomIdWithNonUniqueFallback,
   setHeaderIfNotSet,
 } from "./utils";
-import { isWellFormedUlidString } from "./validation";
+import { assertParamExists, isWellFormedUlidString } from "./validation";
 
 export type UserClientConfigurationParams = UserConfigurationParams & {
   storeId?: string;
@@ -210,9 +210,10 @@ export class OpenFgaClient extends BaseAPI {
     } else {
       this.configuration = new ClientConfiguration(configuration);
     }
+    const { apiUrl } = this.configuration; 
+    assertParamExists("OpenFgaClient", "apiUrl", apiUrl);
+    
     this.configuration.isValid();
-
-
     this.api = new OpenFgaApi(this.configuration, axios);
     this.storeId = configuration.storeId;
     this.authorizationModelId = configuration.authorizationModelId;

--- a/client.ts
+++ b/client.ts
@@ -53,7 +53,7 @@ import {
   generateRandomIdWithNonUniqueFallback,
   setHeaderIfNotSet,
 } from "./utils";
-import { assertParamExists, isWellFormedUlidString } from "./validation";
+import { isWellFormedUlidString } from "./validation";
 
 export type UserClientConfigurationParams = UserConfigurationParams & {
   storeId?: string;

--- a/client.ts
+++ b/client.ts
@@ -210,9 +210,6 @@ export class OpenFgaClient extends BaseAPI {
     } else {
       this.configuration = new ClientConfiguration(configuration);
     }
-    const { apiUrl } = this.configuration; 
-    assertParamExists("OpenFgaClient", "apiUrl", apiUrl);
-    
     this.configuration.isValid();
     this.api = new OpenFgaApi(this.configuration, axios);
     this.storeId = configuration.storeId;

--- a/configuration.ts
+++ b/configuration.ts
@@ -186,7 +186,7 @@ export class Configuration {
    * @throws {FgaValidationError}
    */
   public isValid(): boolean {
-    if (!this.apiUrl && !this.apiScheme && !this.apiHost) {
+    if (!this.apiUrl && !this.apiHost) {
          assertParamExists("Configuration", "apiUrl", this.apiUrl);
        }
 

--- a/configuration.ts
+++ b/configuration.ts
@@ -186,10 +186,9 @@ export class Configuration {
    * @throws {FgaValidationError}
    */
   public isValid(): boolean {
-    if (!this.apiUrl) {
-      assertParamExists("Configuration", "apiScheme", this.apiScheme);
-      assertParamExists("Configuration", "apiHost", this.apiHost);
-    }
+    if (!this.apiUrl && !this.apiScheme && !this.apiHost) {
+         assertParamExists("Configuration", "apiUrl", this.apiUrl);
+       }
 
     if (!isWellFormedUriString(this.getBasePath())) {
       throw new FgaValidationError(


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Provide a brief summary of the changes

- Ensured consistent error handling for missing apiUrl, maintaining backward compatibility with apiScheme and apiHost.
- Simplified the validation logic for cleaner and more reusable code.
## Description
Provide a detailed description of the changes 

This PR refactors the validation logic in the Configuration class to improve error handling for the apiUrl parameter. The changes ensure consistent validation across parameters (apiUrl, apiScheme, and apiHost) and improve readability and maintainability by using the assertParamExists utility function.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
