### PR TITLE
refactor: remove usage of patch file for handling telemetry attributes

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -761,8 +761,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "Check",
         [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
-        [TelemetryAttribute.FgaClientRequestModelId]: body.authorization_model_id ?? "",
-        [TelemetryAttribute.FgaClientUser]: body.tuple_key.user
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
@@ -776,6 +775,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.createStore(body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "CreateStore",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
@@ -789,7 +789,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.deleteStore(storeId, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "DeleteStore",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
       });
     },
     /**
@@ -804,8 +804,8 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.expand(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "Expand",
-        [TelemetryAttribute.FgaClientRequestModelId]: body.authorization_model_id ?? "",
         [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
@@ -819,7 +819,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.getStore(storeId, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "GetStore",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
       });
     },
     /**
@@ -835,12 +835,11 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "ListObjects",
         [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
-        [TelemetryAttribute.FgaClientRequestModelId]: body.authorization_model_id ?? "",
-        [TelemetryAttribute.FgaClientUser]: body.user
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
-         * Returns a paginated list of OpenFGA stores and a continuation token to get additional stores. The continuation token will be empty if there are no more stores.
+         * Returns a paginated list of OpenFGA stores and a continuation token to get additional stores. The continuation token will be empty if there are no more stores. 
          * @summary List all stores
          * @param {number} [pageSize]
          * @param {string} [continuationToken]
@@ -866,7 +865,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "ListUsers",
         [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
-        [TelemetryAttribute.FgaClientRequestModelId]: body.authorization_model_id ?? "",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
@@ -881,11 +880,12 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.read(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "Read",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
-         * The ReadAssertions API will return, for a given authorization model id, all the assertions stored for it. An assertion is an object that contains a tuple key, and the expectation of whether a call to the Check API of that tuple key will return true or false.
+         * The ReadAssertions API will return, for a given authorization model id, all the assertions stored for it. An assertion is an object that contains a tuple key, and the expectation of whether a call to the Check API of that tuple key will return true or false. 
          * @summary Read assertions for an authorization model ID
          * @param {string} storeId
          * @param {string} authorizationModelId
@@ -896,8 +896,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.readAssertions(storeId, authorizationModelId, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "ReadAssertions",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
-        [TelemetryAttribute.FgaClientRequestModelId]: authorizationModelId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
       });
     },
     /**
@@ -912,7 +911,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.readAuthorizationModel(storeId, id, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "ReadAuthorizationModel",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
       });
     },
     /**
@@ -928,7 +927,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.readAuthorizationModels(storeId, pageSize, continuationToken, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "ReadAuthorizationModels",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
       });
     },
     /**
@@ -945,7 +944,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.readChanges(storeId, type, pageSize, continuationToken, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "ReadChanges",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
       });
     },
     /**
@@ -961,7 +960,7 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "Write",
         [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
-        [TelemetryAttribute.FgaClientRequestModelId]: body.authorization_model_id ?? "",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
@@ -977,8 +976,8 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.writeAssertions(storeId, authorizationModelId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "WriteAssertions",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
-        [TelemetryAttribute.FgaClientRequestModelId]: authorizationModelId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
     /**
@@ -993,7 +992,8 @@ export const OpenFgaApiFp = function(configuration: Configuration, credentials: 
       const localVarAxiosArgs = localVarAxiosParamCreator.writeAuthorizationModel(storeId, body, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
         [TelemetryAttribute.FgaClientRequestMethod]: "WriteAuthorizationModel",
-        [TelemetryAttribute.FgaClientRequestStoreId]: storeId,
+        [TelemetryAttribute.FgaClientRequestStoreId]: storeId ?? "",
+        ...TelemetryAttributes.fromRequestBody(body)
       });
     },
   };

--- a/telemetry/attributes.ts
+++ b/telemetry/attributes.ts
@@ -111,4 +111,16 @@ export class TelemetryAttributes {
 
     return attributes;
   }
+
+  static fromRequestBody(body: any, attributes: Record<string, string | number> = {}): Record<string, string | number>  {
+    if (body?.authorization_model_id) {
+      attributes[TelemetryAttribute.FgaClientRequestModelId] = body.authorization_model_id;
+    }
+
+    if (body?.tuple_key?.user) {
+      attributes[TelemetryAttribute.FgaClientUser] = body.tuple_key.user;
+    }
+
+    return attributes;
+  }
 }

--- a/tests/telemetry/attributes.test.ts
+++ b/tests/telemetry/attributes.test.ts
@@ -90,4 +90,20 @@ describe("TelemetryAttributes", () => {
     expect(result["fga-client.response.model_id"]).toEqual("model-id");
     expect(result["http.server.request.duration"]).toEqual(10);
   });
+
+  test("should create attributes from a request body correctly", () => {
+    const body = { authorization_model_id: "model-id", tuple_key: { user: "user:anne" } };
+    const attributes = TelemetryAttributes.fromRequestBody(body);
+
+    expect(attributes[TelemetryAttribute.FgaClientRequestModelId]).toEqual("model-id");
+    expect(attributes[TelemetryAttribute.FgaClientUser]).toEqual("user:anne");
+  });
+
+  test("should create attributes from a request body without tuple_key", () => {
+    const body = { authorization_model_id: "model-id" };
+    const attributes = TelemetryAttributes.fromRequestBody(body);
+
+    expect(attributes[TelemetryAttribute.FgaClientRequestModelId]).toEqual("model-id");
+    expect(attributes[TelemetryAttribute.FgaClientUser]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Description

Removes the patch file that was originally used as a way to handle the store ID, model ID, and tuple key user metrics attributes and instead move to the following:

* `storeId` - Included by the generator if there is a path parameter
* `modelId`/`tuple_key.user` - Body (if present) is passed off to a function in `TelemetryAttributes` that handles creating the correct object.

## References

https://github.com/openfga/sdk-generator/pull/442

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
