### PR TITLE
Use provided axios instance for credentials refresh operations

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -48,7 +48,7 @@ export class BaseAPI {
     }
     this.configuration.isValid();
 
-    this.credentials = Credentials.init(this.configuration);
+    this.credentials = Credentials.init(this.configuration, this.axios);
 
     if (!this.axios) {
       const httpAgent = new http.Agent({ keepAlive: true });

--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -26,9 +26,9 @@ export class Credentials {
   private accessToken?: string;
   private accessTokenExpiryDate?: Date;
 
-  public static init(configuration: { credentials: AuthCredentialsConfig, telemetry: TelemetryConfiguration, baseOptions?: any }): Credentials {
-    return new Credentials(configuration.credentials, globalAxios, configuration.telemetry, configuration.baseOptions);
-  }
+  public static init(configuration: { credentials: AuthCredentialsConfig, telemetry: TelemetryConfiguration, baseOptions?: any }, axios: AxiosInstance = globalAxios): Credentials {
+    return new Credentials(configuration.credentials, axios, configuration.telemetry, configuration.baseOptions);
+}
 
   public constructor(private authConfig: AuthCredentialsConfig, private axios: AxiosInstance = globalAxios, private telemetryConfig: TelemetryConfiguration, private baseOptions?: any) {
     this.initConfig();
@@ -155,7 +155,7 @@ export class Credentials {
       }, {
         maxRetry: 3,
         minWaitInMs: 100,
-      }, globalAxios);
+      }, this.axios);
 
       const response = wrappedResponse?.response;
       if (response) {
@@ -180,7 +180,7 @@ export class Credentials {
 
         attributes = TelemetryAttributes.fromResponse({
           response,
-          attributes,  
+          attributes,
         });
 
         attributes = TelemetryAttributes.prepare(attributes, this.telemetryConfig.metrics?.counterCredentialsRequest?.attributes);


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR ensures that when users provide a custom axios instance to OpenFgaClient, it's consistently used throughout all SDK operations - including credential refresh requests. Previously, credential refresh operations were using the global axios instance, which caused issues for users with custom network configurations like VPC or proxy setups.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #183

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

