### PR TITLE
refactor: check if node via process.versions

### DIFF
--- a/configuration.ts
+++ b/configuration.ts
@@ -171,7 +171,7 @@ export class Configuration {
     const baseOptions = params.baseOptions || {};
     baseOptions.headers = baseOptions.headers || {};
 
-    if (typeof process === "object" && process.title === "node" && !baseOptions.headers["User-Agent"]) {
+    if (typeof process === "object" && process.versions?.node && !baseOptions.headers["User-Agent"]) {
       baseOptions.headers["User-Agent"] = DEFAULT_USER_AGENT;
     }
 


### PR DESCRIPTION
## Description

This removes the `process.title` check for node and uses `process.versions` instead, `process.title`
is not really reliable as it can be set by code, for example some CLIs will rename the process, by using `process.versions.node` we can be more sure that we're in node, unless we're in a runtime that stubs this.

Looking at the libuv codebase we can see that the [`uv_get_process_title`](https://github.com/libuv/libuv/blob/47a5c85c4e7c63adc838d8e252fb4859e6cb743d/src/win/util.c#L390-L424
) function has an assertion that the title retrieved is not empty, given that we've only seen this on Windows it's possible there's some permissions issue or similar that is causing this.

## References

Closes #219


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

