### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
 
-## [Unreleased](https://github.com/openfga/js-sdk/compare/v0.8.1...HEAD)
+## [Unreleased](https://github.com/openfga/js-sdk/compare/v0.9.0...HEAD)
+
+## v0.9.0
+
+### [v0.9.0](https://github.com/openfga/js-sdk/compare/v0.8.1...v0.9.0) (2025-06-03)
+
+- feat: support client assertion for client credentials authentication (#228)
 
 ## v0.8.1
 

--- a/configuration.ts
+++ b/configuration.ts
@@ -22,7 +22,7 @@ const DEFAULT_MAX_RETRY = 3;
 // default minimum wait period in retry - but will backoff exponentially
 const DEFAULT_MIN_WAIT_MS = 100;
 
-const DEFAULT_USER_AGENT = "openfga-sdk js/0.8.1";
+const DEFAULT_USER_AGENT = "openfga-sdk js/0.9.0";
 
 export interface RetryParams {
   maxRetry?: number;
@@ -75,7 +75,7 @@ export class Configuration {
    * @type {string}
    * @memberof Configuration
    */
-  private static sdkVersion = "0.8.1";
+  private static sdkVersion = "0.9.0";
 
   /**
    * provide the full api URL (e.g. `https://api.fga.example`)

--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -91,7 +91,6 @@ export class Credentials {
       assertParamExists("Credentials", "config.clientId", authConfig.config?.clientId);
       assertParamExists("Credentials", "config.apiTokenIssuer", authConfig.config?.apiTokenIssuer);
       assertParamExists("Credentials", "config.apiAudience", authConfig.config?.apiAudience);
-
       assertParamExists("Credentials", "config.clientSecret or config.clientAssertionSigningKey", (authConfig.config as ClientSecretConfig).clientSecret || (authConfig.config as PrivateKeyJWTConfig).clientAssertionSigningKey);
 
       if (!isWellFormedUriString(`https://${authConfig.config?.apiTokenIssuer}`)) {

--- a/example/README.md
+++ b/example/README.md
@@ -31,7 +31,7 @@ Steps
 2. In the Example `package.json` change the `@openfga/sdk` dependency from a semver range like below
 ```json
 "dependencies": {
-    "@openfga/sdk": "^0.8.1"
+    "@openfga/sdk": "^0.9.0"
   }
 ```
 to a `file:` reference like below

--- a/example/example1/package.json
+++ b/example/example1/package.json
@@ -9,7 +9,7 @@
     "start": "node example1.mjs"
   },
   "dependencies": {
-    "@openfga/sdk": "^0.8.1"
+    "@openfga/sdk": "^0.9.0"
   },
   "engines": {
     "node": ">=16.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfga/sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfga/sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "JavaScript and Node.js SDK for OpenFGA",
   "author": "OpenFGA",
   "keywords": [

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -262,7 +262,6 @@ describe("OpenFGA SDK", function () {
       nock.cleanAll();
     });
 
-
     it("should issue a network call to get the token at the first request if client assertion is provided", async () => {
       const scope = nocks.tokenExchange(OPENFGA_API_TOKEN_ISSUER);
       nocks.readAuthorizationModels(baseConfig.storeId!);
@@ -286,13 +285,10 @@ describe("OpenFGA SDK", function () {
       nock.cleanAll();
     });
 
-
-
     it("should allow passing in a configuration instance", async () => {
       const configuration = new Configuration(baseConfig);
       expect(() => new OpenFgaApi(configuration)).not.toThrowError();
     });
-
 
     it("should only accept valid telemetry attributes", async () => {
       expect(


### PR DESCRIPTION
## Description

```
## v0.9.0

### [v0.9.0](https://github.com/openfga/js-sdk/compare/v0.8.1...v0.9.0) (2025-06-03)

- feat: support client assertion for client credentials authentication (#228)
```

## References

https://github.com/openfga/sdk-generator/pull/552

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

