### PR TITLE
chore(ci): restrict semgrep workflow permissions to only read contents

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -5,6 +5,8 @@ on:
       - main
 jobs:
   semgrep:
+    permissions:
+      contents: read
     name: Scan
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/js-sdk/security/code-scanning/1](https://github.com/openfga/js-sdk/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or job to explicitly restrict the `GITHUB_TOKEN` permissions. Since the Semgrep job only needs to check out code and run a scan, it only requires read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the job level (under `semgrep:`), which will apply to this job only. This change should be made directly under the `semgrep:` job definition, before the `name:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security permissions for automated code scanning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->