### PR TITLE
fix: prevent token refresh thundering herd

### DIFF
--- a/credentials/credentials.ts
+++ b/credentials/credentials.ts
@@ -47,6 +47,7 @@ export class Credentials {
   private accessToken?: string;
   private accessTokenExpiryDate?: Date;
   private accessTokenExpiryBufferInMs = 0;
+  private refreshAccessTokenPromise?: Promise<string | undefined>;
 
   public static init(configuration: { credentials: AuthCredentialsConfig, telemetry: TelemetryConfiguration, baseOptions?: any }, axios: AxiosInstance = globalAxios): Credentials {
     return new Credentials(configuration.credentials, axios, configuration.telemetry, configuration.baseOptions);
@@ -146,7 +147,13 @@ export class Credentials {
         return this.accessToken;
       }
 
-      return this.refreshAccessToken();
+      if (!this.refreshAccessTokenPromise) {
+        this.refreshAccessTokenPromise = this.refreshAccessToken().finally(() => {
+          this.refreshAccessTokenPromise = undefined;
+        });
+      }
+
+      return this.refreshAccessTokenPromise;
     }
     }
   }

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -543,18 +543,14 @@ describe("Credentials", () => {
       const apiTokenIssuer = "issuer.fga.example";
       const expectedBaseUrl = "https://issuer.fga.example";
       const expectedPath = `/${DEFAULT_TOKEN_ENDPOINT_PATH}`;
-      let tokenRequestCount = 0;
 
       const scope = nock(expectedBaseUrl)
         .post(expectedPath)
         .once()
         .delay(20)
-        .reply(() => {
-          tokenRequestCount += 1;
-          return [200, {
-            access_token: "shared-token",
-            expires_in: 300,
-          }];
+        .reply(200, {
+          access_token: "shared-token",
+          expires_in: 300,
         });
 
       const credentials = new Credentials(
@@ -578,7 +574,56 @@ describe("Credentials", () => {
       headers.forEach(header => {
         expect(header?.value).toBe("Bearer shared-token");
       });
-      expect(tokenRequestCount).toBe(1);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    test("should clear shared refresh promise after failure and retry on the next call", async () => {
+      const apiTokenIssuer = "issuer.fga.example";
+      const expectedBaseUrl = "https://issuer.fga.example";
+      const expectedPath = `/${DEFAULT_TOKEN_ENDPOINT_PATH}`;
+
+      const scope = nock(expectedBaseUrl)
+        .post(expectedPath)
+        .once()
+        .reply(404, {
+          code: "not_found",
+          message: "token exchange failed",
+        })
+        .post(expectedPath)
+        .once()
+        .reply(200, {
+          access_token: "recovered-token",
+          expires_in: 300,
+        });
+
+      const credentials = new Credentials(
+        {
+          method: CredentialsMethod.ClientCredentials,
+          config: {
+            apiTokenIssuer,
+            apiAudience: OPENFGA_API_AUDIENCE,
+            clientId: OPENFGA_CLIENT_ID,
+            clientSecret: OPENFGA_CLIENT_SECRET,
+          },
+        } as AuthCredentialsConfig,
+        undefined,
+        mockTelemetryConfig,
+      );
+
+      const results = await Promise.allSettled(
+        Array.from({ length: 5 }, () => credentials.getAccessTokenHeader())
+      );
+      const rejected = results.filter((result): result is PromiseRejectedResult => result.status === "rejected");
+
+      expect(rejected).toHaveLength(5);
+      expect(rejected[0].reason).toBe(rejected[1].reason);
+      expect(rejected[1].reason).toBe(rejected[2].reason);
+      expect(rejected[2].reason).toBe(rejected[3].reason);
+      expect(rejected[3].reason).toBe(rejected[4].reason);
+
+      const header = await credentials.getAccessTokenHeader();
+
+      expect(header?.value).toBe("Bearer recovered-token");
       expect(scope.isDone()).toBe(true);
     });
 

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -539,6 +539,48 @@ describe("Credentials", () => {
       expect(scope.isDone()).toBe(true);
     });
 
+    test("should send a single token request for concurrent access token reads", async () => {
+      const apiTokenIssuer = "issuer.fga.example";
+      const expectedBaseUrl = "https://issuer.fga.example";
+      const expectedPath = `/${DEFAULT_TOKEN_ENDPOINT_PATH}`;
+      let tokenRequestCount = 0;
+
+      nock(expectedBaseUrl)
+        .post(expectedPath)
+        .times(5)
+        .delay(20)
+        .reply(() => {
+          tokenRequestCount += 1;
+          return [200, {
+            access_token: "shared-token",
+            expires_in: 300,
+          }];
+        });
+
+      const credentials = new Credentials(
+        {
+          method: CredentialsMethod.ClientCredentials,
+          config: {
+            apiTokenIssuer,
+            apiAudience: OPENFGA_API_AUDIENCE,
+            clientId: OPENFGA_CLIENT_ID,
+            clientSecret: OPENFGA_CLIENT_SECRET,
+          },
+        } as AuthCredentialsConfig,
+        undefined,
+        mockTelemetryConfig,
+      );
+
+      const headers = await Promise.all(
+        Array.from({ length: 5 }, () => credentials.getAccessTokenHeader())
+      );
+
+      headers.forEach(header => {
+        expect(header?.value).toBe("Bearer shared-token");
+      });
+      expect(tokenRequestCount).toBe(1);
+    });
+
     test("should refresh cached token when it is close to expiration", async () => {
       const apiTokenIssuer = "issuer.fga.example";
       const expectedBaseUrl = "https://issuer.fga.example";

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -545,9 +545,9 @@ describe("Credentials", () => {
       const expectedPath = `/${DEFAULT_TOKEN_ENDPOINT_PATH}`;
       let tokenRequestCount = 0;
 
-      nock(expectedBaseUrl)
+      const scope = nock(expectedBaseUrl)
         .post(expectedPath)
-        .times(5)
+        .once()
         .delay(20)
         .reply(() => {
           tokenRequestCount += 1;
@@ -579,6 +579,7 @@ describe("Credentials", () => {
         expect(header?.value).toBe("Bearer shared-token");
       });
       expect(tokenRequestCount).toBe(1);
+      expect(scope.isDone()).toBe(true);
     });
 
     test("should refresh cached token when it is close to expiration", async () => {


### PR DESCRIPTION
## Summary
Ensures concurrent token header reads share one in-flight refresh instead of issuing parallel token exchange requests.

## Changes
- Added regression test asserting 5 parallel calls only trigger 1 token request
- Added an internal `refreshAccessTokenPromise` lock in `Credentials`
- Reused the same refresh promise for concurrent callers and cleared it when settled

## Potential Breaking Change
- Concurrent expired-token requests now share a single refresh result.
- Under transient token endpoint failures, all waiting callers may fail together (instead of independent parallel refresh attempts), which changes failure/retry dynamics.

Fixes #332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized concurrent authentication token requests to prevent duplicate requests and reduce server load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->