### PR TITLE
fix: Correctly set authorization model id when calling batch checks

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -515,11 +515,10 @@ export class OpenFgaClient extends BaseAPI {
       maxParallelRequests = DEFAULT_MAX_METHOD_PARALLEL_REQS,
     } = transaction;
     const { writes, deletes } = body;
-    const authorizationModelId = this.getAuthorizationModelId(options);
 
     if (!transaction?.disable) {
       const apiBody: WriteRequest = {
-        authorization_model_id: authorizationModelId,
+        authorization_model_id: this.getAuthorizationModelId(options),
       };
       if (writes?.length) {
         apiBody.writes = {
@@ -775,7 +774,7 @@ export class OpenFgaClient extends BaseAPI {
     const batchResponses = asyncPool(maxParallelRequests, batchedChecks, async (batch: BatchCheckItem[]) => {
       const batchRequest: BatchCheckRequest = {
         checks: batch,
-        authorization_model_id: options.authorizationModelId,
+        authorization_model_id: this.getAuthorizationModelId(options),
         consistency: options.consistency,
       };
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1547,7 +1547,69 @@ describe("OpenFGA Client", () => {
         } finally {
           expect(scope.isDone()).toBe(true);
         }
-      }); 
+      });
+
+      it("should fallback to client's authorization model when unspecified", async () => {
+        const mockedResponse = {
+          result: {
+            "cor-1": {
+              allowed: true,
+              error: undefined,
+            },
+            "cor-2": {
+              allowed: false,
+              error: undefined,
+            },
+          },
+        };
+
+        const scope = nocks
+          .singleBatchCheck(
+            baseConfig.storeId!,
+            mockedResponse,
+            undefined,
+            undefined,
+            baseConfig.authorizationModelId!,
+          )
+          .matchHeader("X-OpenFGA-Client-Bulk-Request-Id", /.*/);
+
+        expect(scope.isDone()).toBe(false);
+        const response = await fgaClient.batchCheck({
+          checks: [
+            {
+              user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+              relation: "can_read",
+              object: "document",
+              contextualTuples: {
+                tuple_keys: [
+                  {
+                    user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                    relation: "editor",
+                    object: "folder:product",
+                  },
+                  {
+                    user: "folder:product",
+                    relation: "parent",
+                    object: "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+                  },
+                ],
+              },
+              correlationId: "cor-1",
+            },
+            {
+              user: "folder:product",
+              relation: "parent",
+              object: "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+              correlationId: "cor-2",
+            },
+          ],
+        });
+
+        expect(scope.isDone()).toBe(true);
+        expect(response.result).toHaveLength(2);
+        expect(response.result[0].allowed).toBe(true);
+        expect(response.result[1].allowed).toBe(false);
+      });
     });
 
     describe("Expand", () => {


### PR DESCRIPTION
This change fixes a bug where batch checks were not picking up a default authorization model ID which is set on the client level. It causes a huge postgres load unless you manually specify the ID for every call, as it has to fetch the model from the DB on every check.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization model ID resolution to use configured defaults and overrides instead of directly from user-provided options, ensuring consistent behavior across API operations.

* **Tests**
  * Added test coverage for authorization model ID fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->