### PR TITLE
chore(ci): add pre-release lane on develop branch

### DIFF
--- a/.github/workflows/release-please-develop.yml
+++ b/.github/workflows/release-please-develop.yml
@@ -1,0 +1,52 @@
+name: release-please-develop
+
+# Experimental / pre-release lane for the `develop` branch.
+#
+# This is a thin caller around the SHARED reusable workflow
+# openfga/.github/.github/workflows/release-please-prerelease.yml. The common
+# logic lives there so every SDK can onboard by copying just this file.
+#
+# It is completely separate from release-please.yml (the stable main flow):
+#   * targets the long-lived `develop` branch
+#   * only ever cuts pre-release versions (alpha/beta/rc) — enforced by the
+#     reusable workflow. Stable releases must go through main.
+#
+# Triggers:
+#   * workflow_dispatch → build a release PR for an explicit pre-release version
+#   * push to develop   → when the `release:` PR merges, tag + draft + publish
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: >
+          Explicit pre-release version to cut (e.g. 0.10.0-beta.1, 0.10.0-rc.2).
+          Must include an alpha/beta/rc suffix. Stable versions are rejected.
+        required: true
+        type: string
+
+jobs:
+  prerelease:
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'release:')
+    uses: openfga/.github/.github/workflows/release-please-prerelease.yml@main
+    with:
+      trigger-event:   ${{ github.event_name }}
+      release-version: ${{ inputs.release-version || '' }}
+      base-branch:     develop
+      staging-branch:  release-develop
+    secrets:
+      RELEASER_APP_CLIENT_ID:   ${{ secrets.RELEASER_APP_CLIENT_ID }}
+      RELEASER_APP_PRIVATE_KEY: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+      GPG_PRIVATE_KEY:          ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE:           ${{ secrets.GPG_PASSPHRASE }}
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,15 +83,86 @@ chore: bump dependencies                   → (hidden)
 
 ---
 
+## Experimental releases from `develop`
+
+For pre-release builds (beta/rc) of code that isn't on `main` yet, use the
+separate `release-please-develop` workflow. It targets `develop`, only cuts
+pre-release versions, and never touches the stable `main` flow. (It's a thin
+caller around the shared `openfga/.github` `release-please-prerelease.yml`, so
+other SDKs can reuse it.)
+
+`develop` is upstream of `main`:
+
+```
+develop  ●──────●──────●  (0.10.0-beta.1, -beta.2, -rc.1)
+          \             \  promote the code via a normal PR
+main ──────●─────────────●  (0.10.0)
+```
+
+**Promote code, not release commits.** Move features `develop → main` with a
+normal PR. Never merge `develop`'s manifest/CHANGELOG bumps into `main` — they
+set `main` to a pre-release version and break release-please there.
+
+> If the code is already on `main`, you don't need `develop` — cut the beta from
+> `main` with `release-please` using `explicit` (e.g. `0.10.0-beta.1`).
+
+### Cutting a beta
+
+1. Land the code on `develop`.
+2. **Actions → release-please-develop → Run workflow**, enter an explicit
+   pre-release version (e.g. `0.10.0-beta.1`; stable versions are rejected).
+3. Merge the release PR it opens against `develop`. A signed `v0.10.0-beta.1`
+   tag is pushed and published to npm under the `beta` dist-tag (`npm i @openfga/sdk@beta`).
+
+```text
+  ┌─────────────────────────────────────────────┐
+  │  Run workflow  →  version: 0.10.0-beta.1     │
+  └─────────────────────────────────────────────┘
+                       │
+                       ▼
+     stage "Release-As" commit on release-develop
+                       │
+                       ▼
+        release-please opens a release PR
+                       │
+                       ▼  (auto) retargeted to develop
+                ┌──────────────┐
+                │ you merge it │
+                └──────────────┘
+                       │
+                       ▼
+   signed tag  v0.10.0-beta.1  +  draft pre-release
+                       │
+                       ▼
+        main.yaml publishes  →  npm dist-tag: beta
+                       │
+                       ▼
+     release-develop reset to develop (next cycle)
+```
+
+> `release-develop` is an internal scratch branch the workflow manages and
+> resets each run — you never touch it. Your only branch is `develop`.
+
+### Graduating to stable
+
+Promote the code to `main` via a normal PR, then release `0.10.0` on `main` with
+`release-please` using `explicit`. To realign `develop` afterward, open a normal
+`main → develop` PR — both branches are protected, so this stays a reviewed merge
+(no force-pushes, no direct pushes).
+
+---
+
 ## Troubleshooting
 
 **"Invalid previous_tag parameter" error.**
 The manifest version does not have a corresponding GitHub Release object. Reset the
-manifest to the last valid tag:
+manifest to the last valid tag via a PR (`main` is protected, so no direct push):
 ```bash
+git checkout -b fix/reset-manifest
 echo '{ ".": "0.x.y" }' > .release-please-manifest.json
 git commit -am "chore: reset manifest to v0.x.y"
-git push origin main
+git push origin fix/reset-manifest
+# then open and merge a PR into main
 ```
 
 **Duplicate release PRs.**


### PR DESCRIPTION
Adds .github/workflows/release-please-develop.yml: a standalone workflow_dispatch + push(develop) flow that cuts pre-release-only versions (alpha/beta/rc) via release-please, GPG-signed tags and draft pre-releases. It does NOT modify or call the shared openfga/.github release-please workflow, so the stable main flow is untouched. Publishing is handled by the existing main.yaml tag trigger. Documents the develop-upstream branch model in RELEASE.md.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive guide added for experimental pre-releases from the development branch, including step-by-step procedures for cutting beta and RC versions and graduating to stable releases.

* **Chores**
  * Release automation infrastructure updated to support development branch pre-releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->