### PR TITLE
fix: surface stream error chunks in streamedListObjects

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -45,7 +45,7 @@ import {
 import { BaseAPI } from "./base";
 import { CallResult, PromiseResult } from "./common";
 import { Configuration, RetryParams, UserConfigurationParams } from "./configuration";
-import { FgaApiAuthenticationError, FgaRequiredParamError, FgaValidationError } from "./errors";
+import { FgaApiAuthenticationError, FgaError, FgaRequiredParamError, FgaValidationError } from "./errors";
 import {
   chunkArray,
   generateRandomIdWithNonUniqueFallback,
@@ -885,6 +885,9 @@ export class OpenFgaClient extends BaseAPI {
     try {
       for await (const item of parseNDJSONStream(source as any)) {
         const streamResult = item as StreamResultOfStreamedListObjectsResponse;
+        if (streamResult?.error) {
+          throw new FgaError(`StreamedListObjects stream returned an error (code: ${streamResult.error.code}): ${streamResult.error.message}`);
+        }
         if (streamResult?.result?.object) {
           yield { object: streamResult.result.object } as StreamedListObjectsResponse;
         }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1735,6 +1735,33 @@ describe("OpenFGA Client", () => {
         expect(scope.isDone()).toBe(true);
       });
 
+      it("should throw when the stream emits an error chunk", async () => {
+        const ndjsonResponse = [
+          JSON.stringify({ result: { object: "document:1" } }),
+          JSON.stringify({ error: { code: 13, message: "internal stream error" } }),
+        ].join("\n") + "\n";
+
+        const scope = nock(defaultConfiguration.getBasePath())
+          .post(`/stores/${baseConfig.storeId}/streamed-list-objects`)
+          .reply(200, () => Readable.from([ndjsonResponse]), {
+            "Content-Type": "application/x-ndjson"
+          });
+
+        const results: string[] = [];
+        await expect(async () => {
+          for await (const response of fgaClient.streamedListObjects({
+            user: "user:anne",
+            relation: "owner",
+            type: "document",
+          })) {
+            results.push(response.object);
+          }
+        }).rejects.toThrow("StreamedListObjects stream returned an error (code: 13): internal stream error");
+
+        expect(scope.isDone()).toBe(true);
+        expect(results).toEqual(["document:1"]);
+      });
+
       it("should handle retry on 429 error", async () => {
         const objects = ["document:1"];
 


### PR DESCRIPTION
grpc-gateway emits {"error": Status} NDJSON chunks when the stream fails after the 200 header is sent. Throw FgaError instead of silently ending the stream, so consumers do not mistake a truncated result for a complete one.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

