### PR TITLE
docs: update stated node version support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,7 +52,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '24.x'
+        if: matrix.node-version == env.TARGET_NODE_VERSION
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,12 +13,12 @@ env:
   TARGET_NODE_VERSION: '24.x'
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x, 25.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -45,28 +45,6 @@ jobs:
       - name: Build
         run: npm run build
 
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Set up node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.TARGET_NODE_VERSION }}
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Check for circular dependencies
         run: npx madge --circular . --extensions ts,js
 
@@ -74,6 +52,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage to Codecov
+        if: matrix.node-version == '24.x'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
@@ -107,7 +86,7 @@ jobs:
 
   verify-version:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build, test, audit]
+    needs: [build-and-test, audit]
     runs-on: ubuntu-latest
 
     steps:

--- a/SUPPORTED_RUNTIMES.md
+++ b/SUPPORTED_RUNTIMES.md
@@ -1,6 +1,6 @@
 ## Node.js Support Policy for OpenFGA JS SDK
 
-The OpenFGA JavaScript SDK follows the upstream [Node.js release policy](https://nodejs.org/en/about/previous-releases). We support Node.js versions that are currently in **LTS** or **Maintenance** status.
+The OpenFGA JavaScript SDK follows the upstream [Node.js release policy](https://nodejs.org/en/about/previous-releases). We support Node.js versions that are currently in **LTS**, **Current** or **Maintenance** status.
 
 ### Currently Supported Versions
 

--- a/SUPPORTED_RUNTIMES.md
+++ b/SUPPORTED_RUNTIMES.md
@@ -6,10 +6,9 @@ The OpenFGA JavaScript SDK follows the upstream [Node.js release policy](https:/
 
 | Node.js Version | Upstream Support Status | Tested in CI/CD Pipelines |
 |:----------------|:------------------------|:-------------------------:|
-| **20**          | Maintenance             |            Yes            |
-| **22**          | Maintenance             |            Yes            |
+| **22**          | LTS                     |            Yes            |
 | **24**          | LTS                     |            Yes            |
-| **25**          | Current                 |            Yes            |
+| **26**          | Current                 |            Yes            |
 
 ### Support Details
 


### PR DESCRIPTION
## Description

72cc05ec929b5b8359784c70dd292b870c1434e5 - Updates out `SUPPORTED_RUNTIMES` document, Node.js 20 reached EOL on 2026-04-30 and is no longer covered by our support policy (LTS or Maintenance only). Node 22 has since moved from Maintenance to LTS, and Node 25/26 have rolled forward (25 → EOL, 26 → Current).

0bdebeea30bf37821dee0fbeecb6aac8572af07d - Updates the  CI with the following changes:

* Updates the `node-version` matrix to reflect the supported versions change in the prior commit based on our statement that EOL versions are not tested
* Merges `build` and `test` into one step. Solely building on a version doesn't really prove anything about version support, ultimately there we're just testing what TypeScript supports. We now test against all versions in the table, only uploading coverage on one version


## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [xx I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Node.js versions to 22, 24 (LTS), and 26 (Current).
  * Continuous integration now validates builds and tests across all supported Node.js versions.
  * Coverage reporting is maintained for Node.js 24.
  * Version verification now runs after build, test, and audit checks complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->